### PR TITLE
Make Rails 5 compatible

### DIFF
--- a/lib/jsonb_translate/translates.rb
+++ b/lib/jsonb_translate/translates.rb
@@ -24,8 +24,11 @@ module JsonbTranslate
         end
       end
 
-      alias_method_chain :respond_to?, :translates
-      alias_method_chain :method_missing, :translates
+      alias_method :respond_to_without_translates?, :respond_to?
+      alias_method :respond_to?, :respond_to_with_translates?
+
+      alias_method :method_missing_without_translates, :method_missing
+      alias_method :method_missing, :method_missing_with_translates
     end
 
     # Improve compatibility with the gem globalize
@@ -40,6 +43,11 @@ module JsonbTranslate
 
       def enable_fallback(&block)
         toggle_fallback(enabled = true, &block)
+      end
+
+      def respond_to_with_translates?(symbol, include_all = false)
+        return true if parse_translated_attribute_accessor(symbol)
+        respond_to_without_translates?(symbol, include_all)
       end
 
       protected
@@ -73,11 +81,6 @@ module JsonbTranslate
         translations[locale.to_s] = value
         send("#{translation_store}=", translations)
         value
-      end
-
-      def respond_to_with_translates?(symbol, include_all = false)
-        return true if parse_translated_attribute_accessor(symbol)
-        respond_to_without_translates?(symbol, include_all)
       end
 
       def method_missing_with_translates(method_name, *args)


### PR DESCRIPTION
WIP

1. Substitue deprecated `alias_method_chain` with `alias_method`s
2. Move `respond_to_with_translates?` out of protected